### PR TITLE
Bug fix with passing most recent commit

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,16 +50,17 @@ def pytest_report_header():
                     ":",
                     commits[i].message,
                 )
+                break
             # check if no passing commit
             elif i == len(commits) - 1 and getstatus(commits[i].hexsha) == "failure":
                 msg = print(
-                    "\nCan't find passing commit, the most recent commit is failling --> ",
+                    "\nCan't find passing commit, the most recent commit is failing --> ",
                     commits[0].author,
                     ":",
                     commits[0].message,
                 )
                 break
-            # check if current commit is failling
+            # check if current commit is failing
             elif getstatus(commits[i].hexsha) == "failure":
                 pass
             # find the most recent passing commit
@@ -67,16 +68,16 @@ def pytest_report_header():
                 passingcommits = (
                     "\nMost recent passing commit --> "
                     + str(commits[i].author)
-                    + ":"
+                    + ": "
                     + str(commits[i].message)
                 )
                 faillingcommits = ""
-                # looping through all failling commits
+                # looping through all failing commits
                 while i > 0:
                     faillingcommits = (
-                        "\nFailling commit --> "
+                        "\nFailing commit --> "
                         + str(commits[i - 1].author)
-                        + ":"
+                        + ": "
                         + str(commits[i - 1].message)
                         + faillingcommits
                     )


### PR DESCRIPTION
# Fix bug with passing most recent commit
Right now there's a bug where if the most recent commit on the branch passes but the program still attempts to search for another passing commit, and ends up adding the passing commit to the failingcommits list. This fix adds a break line after finding the most recent commit is passing and thus avoids this issue.
<!-- Please include a short summary of the proposed changes. -->
<!-- Also include any other relevant information that is useful for this pull request. -->

Additionally fixes some output spelling errors.

## Type of Change

Please describe the pull request as one of the following:

- [X] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update
- [ ] Other <!-- Please specify any helpful information below -->

## Tags

<!-- Please tag those who are responsible for reviewing proposed changes below. -->
<!-- Don't forget to assign people who is going to work on this issue and add labels. -->
